### PR TITLE
Add policyOnly option

### DIFF
--- a/daemon/settings.json.in
+++ b/daemon/settings.json.in
@@ -2,6 +2,7 @@
 	"policiesDir": "@CMAKE_INSTALL_PREFIX@/etc/@CMAKE_PROJECT_NAME@/policies",
 	"exceptionsFile": "@CMAKE_INSTALL_PREFIX@/var/@CMAKE_PROJECT_NAME@/exceptions.bin",
 	"liveUpdateFile": "@CMAKE_INSTALL_PREFIX@/var/@CMAKE_PROJECT_NAME@/intro_live_update.bin",
+	"policyOnly": false,
 	"pageCacheLimit": 512,
 	"useAltp2m": false,
 	"disableQueryHeap": false,

--- a/daemon/src/hvmidomainhandler.cpp
+++ b/daemon/src/hvmidomainhandler.cpp
@@ -193,7 +193,7 @@ bool HvmiDomainHandler::loadPolicy( const std::string &uuid, HvmiSettings &setti
 	if ( !ret && log )
 		bdvmi::logger << bdvmi::WARNING << "[" << uuid << "] No policy available for domain" << std::flush;
 
-	if ( settings_.licensedOnly_ && !ret ) {
+	if ( settings_.policyOnly_ && !ret ) {
 		if ( log )
 			bdvmi::logger << bdvmi::WARNING << "[" << uuid << "] Won't hook unlicensed domain"
 			              << std::flush;

--- a/daemon/src/hvmisettings.cpp
+++ b/daemon/src/hvmisettings.cpp
@@ -76,7 +76,7 @@ void HvmiSettings::copyFrom( const HvmiSettings &other )
 	introspectionOptions_    = other.introspectionOptions_;
 	name_                    = other.name_;
 	polid_                   = other.polid_;
-	licensedOnly_            = other.licensedOnly_;
+	policyOnly_              = other.policyOnly_;
 	kmEnabled_               = other.kmEnabled_;
 	umEnabled_               = other.umEnabled_;
 	policyApplied_           = other.policyApplied_;
@@ -106,7 +106,7 @@ void HvmiSettings::reset()
 	protectedProcesses_.clear();
 	polid_.clear();
 	name_.clear();
-	licensedOnly_    = true;
+	policyOnly_      = true;
 	kmEnabled_       = true;
 	policyApplied_   = false;
 	protectionsHash_ = 0;
@@ -173,6 +173,8 @@ bool HvmiSettings::parseSettingsJson( const std::string &contents )
 	useAltp2m_      = settings["useAltp2m"].asBool();
 
 	disableQueryHeap_ = settings["disableQueryHeap"].asBool();
+
+	policyOnly_ = settings["policyOnly"].asBool();
 
 	logUnprotectedProcesses_ = settings["loadUnprotectedProcesses"].asBool();
 

--- a/daemon/src/hvmisettings.h
+++ b/daemon/src/hvmisettings.h
@@ -146,7 +146,7 @@ public:
 	mutable std::mutex                                        mutex_;
 	std::string                                               polid_;
 	std::string                                               name_;
-	bool                                                      licensedOnly_{ true }; // registry only
+	bool                                                      policyOnly_{ true };
 	bool                                                      kmEnabled_{ true };
 	bool                                                      umEnabled_{ true };
 	bdvmi::BackendFactory::BackendType                        backend_{ bdvmi::BackendFactory::BACKEND_XEN };

--- a/daemon/src/introcoremanager.cpp
+++ b/daemon/src/introcoremanager.cpp
@@ -1008,7 +1008,7 @@ void IntrocoreManager::generateSessionId()
 	// sessionId_ = ??
 }
 
-bool IntrocoreManager::injectAgent( const Tool &agent )
+bool IntrocoreManager::injectAgent( const Tool /* &agent */ )
 {
 	bdvmi::logger << bdvmi::ERROR << "Agent injection is not supported yet!" << std::flush;
 


### PR DESCRIPTION
hvmid does not hook domains without an associated policy json. This new option will allow the user to control if hvmid should only hook domains with a policy file, or hook any domain and apply the default policy.
