### PR TITLE
Install target should also build cami & exceptions and install them

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,7 @@ set(DEST_DIR "${CMAKE_INSTALL_PREFIX}")
 set(LIB_DIR "${CMAKE_INSTALL_LIBDIR}")
 set(INC_DIR "${CMAKE_INSTALL_INCLUDEDIR}")
 set(PRIVATE_LIBS "-l${CMAKE_PROJECT_NAME}")
+set(DATA_DIR "${CMAKE_INSTALL_DATADIR}")
 
 CONFIGURE_FILE("${CMAKE_SHARED_LIBRARY_PREFIX}${CMAKE_PROJECT_NAME}.pc.in"
                "${PROJECT_SOURCE_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${CMAKE_PROJECT_NAME}.pc"
@@ -451,14 +452,16 @@ endif()
 
 if (PYTHON_EXE)
     get_filename_component(PROJECT_EXCEPTION_PATH "${PROJECT_SOURCE_DIR}/exceptions" REALPATH)
-    add_custom_target(exceptions
-        COMMAND python3 exceptions.py --build=${project_exceptions_build} --verbose=2 jsons --output exceptions.bin
+    add_custom_target(exceptions ALL
+        COMMAND python3 exceptions.py --build=${project_exceptions_build} --verbose=2 jsons --output "${${CMAKE_PROJECT_NAME}_BINARY_DIR}/exceptions.bin"
         WORKING_DIRECTORY ${PROJECT_EXCEPTION_PATH})
+    INSTALL(FILES "${${CMAKE_PROJECT_NAME}_BINARY_DIR}/exceptions.bin" DESTINATION "${CMAKE_INSTALL_FULL_DATADIR}/${CMAKE_PROJECT_NAME}")
 endif()
 
 if (PYTHON_EXE)
     get_filename_component(PROJECT_CAMI_PATH "${PROJECT_SOURCE_DIR}/cami" REALPATH)
-    add_custom_target(cami
-        COMMAND python3 scripts/main.py --major ${project_cami_major} --minor ${project_cami_minor} --buildnumber ${project_cami_build} --output intro_live_update.bin
+    add_custom_target(cami ALL
+        COMMAND python3 scripts/main.py --major ${project_cami_major} --minor ${project_cami_minor} --buildnumber ${project_cami_build} --output "${${CMAKE_PROJECT_NAME}_BINARY_DIR}/intro_live_update.bin"
         WORKING_DIRECTORY ${PROJECT_CAMI_PATH})
+    INSTALL(FILES "${${CMAKE_PROJECT_NAME}_BINARY_DIR}/intro_live_update.bin" DESTINATION "${CMAKE_INSTALL_FULL_DATADIR}/${CMAKE_PROJECT_NAME}")
 endif()

--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -36,8 +36,10 @@ endif()
 find_package(PkgConfig REQUIRED)
 
 pkg_check_modules(BDVMI REQUIRED libbdvmi)
-pkg_check_modules(INTROCORE REQUIRED libintrocore)
 pkg_check_modules(JSONCPP REQUIRED jsoncpp)
+
+pkg_check_modules(INTROCORE REQUIRED libintrocore)
+pkg_get_variable(INTROCORE_DATADIR libintrocore pkgdatadir)
 
 add_executable(${CMAKE_PROJECT_NAME})
 

--- a/daemon/settings.json.in
+++ b/daemon/settings.json.in
@@ -1,7 +1,7 @@
 {
 	"policiesDir": "@CMAKE_INSTALL_PREFIX@/etc/@CMAKE_PROJECT_NAME@/policies",
-	"exceptionsFile": "@CMAKE_INSTALL_PREFIX@/var/@CMAKE_PROJECT_NAME@/exceptions.bin",
-	"liveUpdateFile": "@CMAKE_INSTALL_PREFIX@/var/@CMAKE_PROJECT_NAME@/intro_live_update.bin",
+	"exceptionsFile": "@INTROCORE_DATADIR@/exceptions.bin",
+	"liveUpdateFile": "@INTROCORE_DATADIR@/intro_live_update.bin",
 	"policyOnly": false,
 	"pageCacheLimit": 512,
 	"useAltp2m": false,

--- a/daemon/src/introcoremanager.cpp
+++ b/daemon/src/introcoremanager.cpp
@@ -1008,7 +1008,7 @@ void IntrocoreManager::generateSessionId()
 	// sessionId_ = ??
 }
 
-bool IntrocoreManager::injectAgent( const Tool /* &agent */ )
+bool IntrocoreManager::injectAgent( const Tool & /* agent */ )
 {
 	bdvmi::logger << bdvmi::ERROR << "Agent injection is not supported yet!" << std::flush;
 

--- a/libintrocore.pc.in
+++ b/libintrocore.pc.in
@@ -1,10 +1,14 @@
 dir_prefix=@DEST_DIR@
 lib=@LIB_DIR@
 include=@INC_DIR@
+data_dir=@DATA_DIR@
 
 prefix=${dir_prefix}
 lib_dir=${dir_prefix}/${lib}
 include_dir=${dir_prefix}/${include}
+
+datarootdir=${dir_prefix}/${data_dir}
+pkgdatadir=${datarootdir}/introcore
 
 Name: introcore
 Description: Hypervisor Memory Introspection


### PR DESCRIPTION
* cami and exceptions will be built by default.
* make install will also install cami and exceptions.
* cami & exceptions install path will be exported in the pkgconfig file.