### PR TITLE
Fix the language detected by GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,6 @@
 *.vcxproj text eol=crlf
 *.filters text eol=crlf
 *.bat text eol=crlf
+
+introcore/include/*.h linguist-language=C
+introcore/agents/windows/scripts/*.h linguist-language=C

--- a/.gitattributes
+++ b/.gitattributes
@@ -16,5 +16,6 @@
 *.filters text eol=crlf
 *.bat text eol=crlf
 
+docs/* linguist-documentation
 introcore/include/*.h linguist-language=C
 introcore/agents/windows/scripts/*.h linguist-language=C


### PR DESCRIPTION
This is based on the [Troubleshooting](https://github.com/github/linguist#my-repository-is-detected-as-the-wrong-language) section of the linguist docs.

Running `github-linguist` locally gives the following results:

```console
$ github-linguist
76.58%  Objective-C
19.62%  C
2.31%   C++
1.00%   Python
0.37%   Assembly
0.08%   CMake
0.02%   Makefile
0.01%   Batchfile
0.01%   Shell
```

Using `github-linguist --breakdown`, we can see the files that are detected as `Objective-C`:

```console
$ github-linguist --breakdown
Objective-C:
introcore/agents/windows/scripts/agent32.h
introcore/agents/windows/scripts/agent64.h
introcore/agents/windows/scripts/trampoline32.h
introcore/agents/windows/scripts/trampoline64.h
introcore/include/winagent_dummy_Win32.h
introcore/include/winagent_dummy_x64.h
introcore/include/winagent_gather_Win32.h
introcore/include/winagent_gather_x64.h
introcore/include/winagent_killer_Win32.h
introcore/include/winagent_killer_x64.h
introcore/include/winagent_ptdriver_x64.h
introcore/include/winagent_ve_x64.h
introcore/include/winbootdrv_Win32.h
introcore/include/winbootdrv_x64.h
```

Running the same command now should output:

```console
$ github-linguist
97.03%  C
1.48%   C++
1.00%   Python
0.37%   Assembly
0.08%   CMake
0.02%   Makefile
0.01%   Batchfile
0.01%   Shell
```