### PR TITLE
Manage submodule updates using dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "dependabot"
+      include: "scope"
+  

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+      time: "17:15"
+      timezone: "Europe/Bucharest"
     commit-message:
       prefix: "dependabot"
       include: "scope"


### PR DESCRIPTION
This adds a configuration file that enables dependabot submodule updates.

Currently, dependabot is configured to check for submodule updates daily at 17:15 (I wanted to check how it works live, but I can change the hour as needed) and it will open a PR with the update (see ianichitei/hvmi#2 for an example). 

PRs need to be reviewed, but commenting `@dependabot merge` (or `@dependabot squash and merge`) will merge (or squash and merge) the PR once all the other checks pass (so it can't break the build). It will not open more than 5 PRs at once, so if we don't merge them for some time it will stop until we start merging again. 

For other possible configuration options check [the official docs](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates). 

I merged the PR dependabot opened on my fork so this will also update `bddisasm`. 