### PR TITLE
Clean up radare output

### DIFF
--- a/cami/tools/r2cami/r2wrapper.py
+++ b/cami/tools/r2cami/r2wrapper.py
@@ -68,7 +68,7 @@ class R2Wrapper:
         return json.loads(s)
 
     def read_bytes(self, addr, size):
-        b = bytes.fromhex(self.pipe.cmd(f"p8 {size} @ {addr}"))
+        b = bytes.fromhex(self.pipe.cmd(f"p8 {size} @ {addr}").strip())
         if len(b) != size:
             raise LookupError(f"Failed to read {size} bytes from {addr}")
         return b


### PR DESCRIPTION
On some versions of radare, a space is appended to the byte output. This becomes an issue when parsing the output as hex and will show the following error:
`ValueError: non-hexadecimal number found in fromhex() arg at position 4`

This issue is fixed by stripping the leading and trailing spaces (if there are any) before parsing the data as hex.