### PR TITLE
Don't fail MZPE validation for small (less than 4K) files

### DIFF
--- a/introcore/include/memtags.h
+++ b/introcore/include/memtags.h
@@ -138,4 +138,6 @@
 
 #define IC_TAG_IOBD             'DBOI'          ///< Used for interrupt object protection descriptors.
 
+#define IC_TAG_SMALL_MZPE       ':EPS'          ///< Small MZPE.
+
 #endif // _MEMTAGS_H_


### PR DESCRIPTION
Fixes #64.

We can probably safely remove the check as the size is passed to all functions that touch the buffer and it appears to be no real constraint for the buffer to be >= 4KB, but I'd rather post-pone that check until after the winter holidays in order to properly test it.